### PR TITLE
chore(ci): bump golangci-lint to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
               with:
                   go-version: ${{ matrix.go }}
             - name: golangci-lint
-              uses: golangci/golangci-lint-action@v6
+              uses: golangci/golangci-lint-action@v8
               with:
-                  version: v1.64
+                  version: v2.1
     go-checks:
         name: ${{ matrix.check }}
         strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: "2"
 # Options for analysis running.
 run:
     # Include test files or not.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflow to use newer versions of golangci-lint.
  - Added a version key to the linter configuration file for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->